### PR TITLE
Improve efficiency of etag calculations

### DIFF
--- a/.idea/modules/app.iml
+++ b/.idea/modules/app.iml
@@ -16,43 +16,43 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="sbt: ch.qos.logback:logback-classic:1.2.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-dynamodb:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-cloudwatchmetrics:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: ch.qos.logback:logback-core:1.2.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-core:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-kms:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-s3:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-core:2.6.7:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-databind:2.6.7.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7:jar" level="project" />
-    <orderEntry type="library" name="sbt: commons-codec:commons-codec:1.10:jar" level="project" />
-    <orderEntry type="library" name="sbt: commons-logging:commons-logging:1.1.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: junit:junit:4.12:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-all:1.10.19:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.6:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang:scala-reflect:2.12.6:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.slf4j:jcl-over-slf4j:1.7.25:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-junit_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-matcher_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-mock_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-cloudwatch:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-mock_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-matcher_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-junit_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.slf4j:jcl-over-slf4j:1.7.25:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang:scala-reflect:2.12.6:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.6:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-all:1.10.19:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: junit:junit:4.12:jar" level="project" />
+    <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: commons-logging:commons-logging:1.1.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: commons-codec:commons-codec:1.10:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-databind:2.6.7.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-core:2.6.7:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-s3:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-kms:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-core:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: ch.qos.logback:logback-core:1.2.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-cloudwatchmetrics:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-dynamodb:1.11.372:jar" level="project" />
   </component>
 </module>

--- a/.idea/modules/app.iml
+++ b/.idea/modules/app.iml
@@ -16,43 +16,43 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="sbt: ch.qos.logback:logback-classic:1.2.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-cloudwatch:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-mock_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-matcher_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-junit_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.slf4j:jcl-over-slf4j:1.7.25:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang:scala-reflect:2.12.6:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.6:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-all:1.10.19:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: junit:junit:4.12:jar" level="project" />
-    <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: commons-logging:commons-logging:1.1.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: commons-codec:commons-codec:1.10:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-databind:2.6.7.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-core:2.6.7:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-s3:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-kms:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-core:1.11.372:jar" level="project" />
-    <orderEntry type="library" name="sbt: ch.qos.logback:logback-core:1.2.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-cloudwatchmetrics:1.11.372:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-dynamodb:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-cloudwatchmetrics:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: ch.qos.logback:logback-core:1.2.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-core:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-kms:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-s3:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.372:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-core:2.6.7:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-databind:2.6.7.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7:jar" level="project" />
+    <orderEntry type="library" name="sbt: commons-codec:commons-codec:1.10:jar" level="project" />
+    <orderEntry type="library" name="sbt: commons-logging:commons-logging:1.1.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: junit:junit:4.12:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-all:1.10.19:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.6:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang:scala-reflect:2.12.6:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.slf4j:jcl-over-slf4j:1.7.25:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-junit_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-matcher_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-mock_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-cloudwatch:1.11.372:jar" level="project" />
   </component>
 </module>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+Upload Flush List (Multi-threaded)
+====
+
+This project is a program for emergency use, to quickly "flush" large media files
+into S3 storage and remove them from local storage.
+
+A paranoid approach is taken by re-verifying the e-tag and file size once upload
+is complete in order to ensure that no files become corrupted during the process.
+
+Description
+---
+
+#### Input
+As an input, the program expects a list of (absolute) file paths indicating the
+specific files to upload and remove.  We generate this from a seperate database.
+Two formats are supported:
+
+1. Plain file list, as a Unix standard UTF-8 text file with one file on each line,
+separated by Linefeed (LF) characters
+2. CSV format, as a Unix standard UTF-8 text file, with two colums where the second
+column indicates the filepath
+
+This file should be called `to_flush.lst` and in the directory that you are running the program from.
+
+#### Arguments
+Runtime parameters are specified as system properties.  They can be specified on the
+commandline using the standard -Dparameter=value syntax:
+
+- **maxThreads** (number; default 48) - maximum number of threads to use for upload.
+- **reallyDelete** (boolean; default false) - if set to any string, delete files from local storage.
+Otherwise treat the run as a test and don't delete anything.
+- **limit** (number; default not set) - if set, stop after this many files. Used for testing.
+- **destBucket** (string; must be set) - upload to this S3 bucket
+- **stripPathSegments** (number; default 5) - remove this number of segments from the local path to generate
+the remote path.  For example, if the local path is `/mnt/media_volume/my_project/files/card01/file.mxf` and
+**stripPathSegments** is set to `2`, then the remote path will be
+ `s3://{destBucket}/my_project/files/card01/file.mxf`.
+- **chunkSize** (number; default 50) - upload chunk size in megabytes.  This allows you to optimize for your
+disk and network speeds.  The chunk size can't be less than 4Mb due to S3 limits
+and can't be so small that any file has more than 999 chunks.
+Multiple chunks are uploaded in parallel, one per thread.
+- **hideNotFound** (boolean; default false) - By default, a warning is shown if any requested file is not
+ found on the local disk.  Setting this parameter to any string hides these warnings.
+
+#### Logging
+Logging is carried out by the standard log4j plugin which is configured via the `logback.xml` file.  In order
+to customise the logging, copy the existing `logback.xml` file from `src/main/resources/logback.xml` to your
+server and edit it to suit your needs.  Then run the program with the parameter `FIXME` to use your updated
+configuration.  The default logger outputs to standard out and shows the MtUploader at `DEBUG` level.
+See online documentation about configuring logback.xml to understand how to output to a file, adjust logging
+priorities, formats etc.
+
+Compilation
+---
+This project uses `sbt` and the SBT Universal Packaging plugin to make your life easier.
+
+With `sbt` installed, on a RedHat linux-based system (or container) simply run:
+```
+$ sbt rpm:packageBin
+```
+to download all necessary requirements, compile, link and make an RPM of the products.
+Other packageBin options from Universal Packager should work but are untested.
+
+#### Do Docker?
+If you have Docker installed, then you can use the `Dockerfile` in the `.circleci` directory
+to quickly make an environment suitable for compiling, building and running the program.
+
+Simply change to the .circleci directory and run:
+```
+$ docker build . -t {yourname}/{imagename}:{version}
+$ docker run --rm -it -mount 'type=bind,src={checkout-path},dst=/mnt' {yourname}/{imagename}:{version}
+```
+substituting the values in braces for your setup.  Then in the Docker container:
+```
+$ cd mnt
+$ sbt rpm:packageBin
+$ mv target/rpm/RPMS/noarch/ /mnt
+```
+to get the built RPM package in your current directory.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ separated by Linefeed (LF) characters
 2. CSV format, as a Unix standard UTF-8 text file, with two colums where the second
 column indicates the filepath
 
-This file should be called `to_flush.lst` and in the directory that you are running the program from.
+See the samples in `src/test/resources` for examples that are used in testing.
 
 #### Arguments
+You must specify the path to the list of files you want to upload as the only conventional commandline
+argument.  The program will exit if you don't do this.
+
 Runtime parameters are specified as system properties.  They can be specified on the
 commandline using the standard -Dparameter=value syntax:
 

--- a/src/main/scala/EtagCalculator.scala
+++ b/src/main/scala/EtagCalculator.scala
@@ -1,6 +1,8 @@
 import java.io.File
 import java.io.FileInputStream
+import java.nio.channels.FileChannel
 import java.security.MessageDigest
+import java.nio.{ByteBuffer, MappedByteBuffer}
 
 import org.apache.commons.codec.binary.Hex
 import org.slf4j.LoggerFactory
@@ -15,69 +17,81 @@ object EtagCalculator {
     MessageDigest.getInstance("md5").digest(str)
   }
 
-  def md5NextChunk(stream:FileInputStream, chunkNum:Int, chunkSize:Int, lastChunkSize:Int, totalChunks:Int, md5List:Seq[Array[Byte]])(implicit  exec:ExecutionContext):Seq[Array[Byte]] = {
-    if(chunkNum>totalChunks) return md5List
-
-    logger.debug(s"reading chunk $chunkNum of $totalChunks")
-    var bytes = if(chunkNum<totalChunks){
-      val bytes = Array.fill[Byte](chunkSize)(0)
-      stream.read(bytes,0,chunkSize)
-      bytes
-    } else {
-      val bytes = Array.fill[Byte](lastChunkSize)(0)
-      stream.read(bytes,0, lastChunkSize)
-      bytes
-    }
-
-    val updatedList = md5List :+ md5Of(bytes)
-
-    md5NextChunk(stream, chunkNum+1, chunkSize,lastChunkSize, totalChunks, updatedList)
+  def md5Of(buffer:ByteBuffer):Array[Byte] = {
+    val instance = MessageDigest.getInstance("md5")
+    instance.update(buffer)
+    instance.digest()
   }
 
-  def eTagForFile(file:File, chunkSize:Int)(implicit  exec:ExecutionContext):String = {
-    val stream = new FileInputStream(file)
+  def md5NextChunk(file:File, chunkNum:Int, chunkSize:Int, lastChunkSize:Int, totalChunks:Int, md5List:Seq[Future[Array[Byte]]])(implicit  exec:ExecutionContext):Seq[Future[Array[Byte]]] = {
+    if(chunkNum>totalChunks) return md5List
+
+    val updatedList = md5List :+ Future {
+      val stream = new FileInputStream(file)
+
+      logger.debug(s"${file.getPath}: reading chunk $chunkNum of $totalChunks")
+      var buffer = if (chunkNum < totalChunks) {
+        stream.getChannel.map(FileChannel.MapMode.READ_ONLY, chunkNum * chunkSize, chunkSize)
+      } else {
+        stream.getChannel.map(FileChannel.MapMode.READ_ONLY, chunkNum * chunkSize, lastChunkSize)
+      }
+      stream.close()
+      md5Of(buffer)
+    }
+
+    md5NextChunk(file, chunkNum+1, chunkSize,lastChunkSize, totalChunks, updatedList)
+  }
+
+  /**
+    * Calculates the expected etag for the file.  This is done in as parallel a manner as possible
+    * @param file java.nio.File object representing the file to check
+    * @param chunkSize chunk size with which it is uploaded. This is needed for an accurate etag calculation
+    * @param exec implicitly provided execution context
+    * @return a Future, containing a String of the expected etag
+    */
+  def eTagForFile(file:File, chunkSize:Int)(implicit  exec:ExecutionContext):Future[String] = {
     logger.debug(s"calculating local etag for file ${file.getAbsolutePath}")
-    logger.debug(s"file size is ${file.length} chunk size is ${chunkSize}")
+    logger.debug(s"file size is ${file.length} chunk size is $chunkSize")
     val totalChunks = math.ceil(file.length() / chunkSize).toInt
     logger.debug(s"total chunks: $totalChunks")
     if (totalChunks == 0) {
       /*for an unchunked upload then the hash is simply the md5 of the entire file*/
-      val bytes = Array.fill[Byte](file.length().toInt)(0)
-      stream.read(bytes)
-      //md5Of(bytes).map(bs=>Hex.encodeHexString(bs))
-      Hex.encodeHexString(md5Of(bytes))
+      Future {
+        val stream = new FileInputStream(file)
+        val bytes = stream.getChannel.map(java.nio.channels.FileChannel.MapMode.READ_ONLY, 0, file.length())
+        stream.close()
+        Hex.encodeHexString(md5Of(bytes))
+      }
     } else {
       val lastChunkSize = (file.length() - totalChunks * chunkSize).toInt
       logger.debug(s"last chunk size: $lastChunkSize")
-      val md5Seq = md5NextChunk(stream, 0, chunkSize, lastChunkSize, totalChunks, Seq())
-      stream.close()
+      val md5Seq = Future.sequence(md5NextChunk(file, 0, chunkSize, lastChunkSize, totalChunks, Seq()))
 
-//      /* ensure that the FileInputStream is closed */
-//      md5Seq.onComplete({
-//        case Failure(err) =>
-//          logger.error(s"${file.getAbsolutePath}: Could not calculate md5 chain", err)
-//          stream.close()
-//        case Success(seq) =>
-//          logger.debug(s"${file.getAbsolutePath}: Calculated md5 chain")
-//          stream.close()
-//      })
-      val finalByteString: Array[Byte] = md5Seq.reduce((acc, item) => acc ++ item)
-      //md5Of(finalByteString).map(bs => Hex.encodeHexString(bs) + s"-${totalChunks + 1}")
-      Hex.encodeHexString(md5Of(finalByteString)) + s"-${totalChunks + 1}"
+      /* general logging message */
+      md5Seq.onComplete({
+        case Failure(err) =>
+          logger.error(s"${file.getAbsolutePath}: Could not calculate md5 chain", err)
+        case Success(seq) =>
+          logger.debug(s"${file.getAbsolutePath}: Calculated md5 chain")
+      })
 
       /* reduce the list of portions back to a single one */
-//      md5Seq.flatMap(md5Parts => {
-//        val finalByteString: Array[Byte] = md5Parts.reduce((acc, item) => acc ++ item)
-//        md5Of(finalByteString).map(bs => Hex.encodeHexString(bs) + s"-${totalChunks + 1}")
-//      })
+      md5Seq.map(md5Parts => {
+        val finalByteString: Array[Byte] = md5Parts.reduce((acc, item) => acc ++ item)
+        Hex.encodeHexString(md5Of(finalByteString)) + s"-${totalChunks + 1}"
+      })
     }
   }
 
-  def propertiesForFile(file:File, chunkSize:Int)(implicit  exec:ExecutionContext):Future[LocalFileProperties] = Future {
+  def propertiesForFile(file:File, chunkSize:Int)(implicit  exec:ExecutionContext):Future[LocalFileProperties] = {
     val etagFuture = eTagForFile(file, chunkSize)
     val localFileSize = file.length()
 
-    //etagFuture.map(eTag=>LocalFileProperties(eTag, localFileSize))
-    LocalFileProperties(etagFuture, localFileSize)
+    if(file.length()>chunkSize){
+      //if we put a lot of chunks onto the queue, then delay returning a little to try to make sure that they get added together
+      Thread.sleep(Math.ceil(0.1*(file.length/chunkSize)).toLong)
+    }
+
+    etagFuture.map(eTag=>LocalFileProperties(eTag, localFileSize))
   }
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -107,7 +107,7 @@ object Main extends App {
 
     val lp = new ListParser(listFileName, noProjects)
 
-    val uploader = new MtUploader(destBucket, pathSegments)
+    val uploader = new MtUploader(destBucket, pathSegments, chunkSize)
 
     var notFoundCounter=0
     var zeroLengthCounter=0

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -53,7 +53,7 @@ object Main extends App {
     }
 
     implicit val exec:ExecutionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
-    val uploadExecContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool((maxThreads.toDouble*2.toDouble/3.toDouble).toInt))
+    val uploadExecContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(maxThreads))
 
     val logger = LoggerFactory.getLogger(getClass)
     lazy val clientConfg:ClientConfiguration = new ClientConfiguration()

--- a/src/test/scala/EtagCalculatorSpec.scala
+++ b/src/test/scala/EtagCalculatorSpec.scala
@@ -17,13 +17,13 @@ class EtagCalculatorSpec extends Specification {
   "EtagCalculator.eTagForFile" should {
     "calculate a single md5 hash for a file if it is larger than the given chunk size" in {
       val f = new File("./src/test/resources/sample2.lst")
-      val result = EtagCalculator.eTagForFile(f,40960)
+      val result = Await.result(EtagCalculator.eTagForFile(f,40960), 5.seconds)
       result shouldEqual "89684d80211bdff0b4db7db7be362e9c"
     }
 
     "calculate a compound md5 hash for a file if it is larger than the given chunk size" in {
       val f = new File("./src/test/resources/sample2.lst")
-      val result = EtagCalculator.eTagForFile(f,6)
+      val result = Await.result(EtagCalculator.eTagForFile(f,6), 5.seconds)
       result shouldEqual "5e1534261e035cd0325d0888626103c4-21"
     }
   }


### PR DESCRIPTION
Uses mmap rather than reads to calculate etags and thereby make them more parallel again.
Remove hard-coded chunk-size and make it configurable via system property